### PR TITLE
Update MSFT_SPSearchContentSource.psm1 issue #840

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change log for SharePointDsc
+## Unreleased
+
+* MSFT_SPSearchContentSource
+  * Fixed issue where the parameter StartHour was never taken into account (issue 840)
 
 ## 2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,43 @@
 # Change log for SharePointDsc
+
 ## Unreleased
 
-* MSFT_SPSearchContentSource
+* SPCacheAccounts
+  * Fixed issue where the Test method would fail if SetWebAppPolicy was set to
+    false.
+* SPDistributedCacheService
+  * Updated resource to allow updating the cache size
+* SPFarm
+  * Implemented ability to deploy Central Administration site to a server at a
+    later point in time
+* SPInfoPathFormsServiceConfig
+  * Fixed issue with trying to set the MaxSizeOfUserFormState parameter
+* SPProductUpdate
+  * Fixed an issue where the resource failed when the search was already paused
+* SPProjectServerLicense
+  * Fixed issue with incorrect detection of the license
+* SPSearchContentSource
+  * Fixed issue where the Get method returned a conversion error when the content
+    source contained just one address
   * Fixed issue where the parameter StartHour was never taken into account (issue 840)
+* SPSearchServiceApp
+  * Fixed issue where the service account was not set correctly when the service
+    application was first created
+  * Fixed issue where the Get method throws an error when the service app wasn't
+    created properly
+* SPSearchTopology
+  * Fixed issue where Get method threw an error when the specified service
+    application didn't exist yet.
+* SPServiceAppSecurity
+  * Fixed issue where error was thrown when no permissions were set on the
+    service application
+* SPShellAdmins
+  * Updated documentation to specify required permissions for successfully using
+    this resource
+* SPTrustedIdentityTokenIssuerProviderRealms
+  * Fixed code styling issues
+* SPUserProfileServiceApp
+  * Fixed code styling issues
 
 ## 2.3
 
@@ -646,3 +681,4 @@ The following changes will break 1.x configurations that use these resources:
 ## 0.2.0
 
 * Initial public release of xSharePoint
+

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchContentSource/MSFT_SPSearchContentSource.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchContentSource/MSFT_SPSearchContentSource.psm1
@@ -517,6 +517,14 @@ function Set-TargetResource
                     $incrementalSetArgs.Add("CrawlScheduleRunEveryInterval", 
                         $params.IncrementalSchedule.CrawlScheduleRunEveryInterval)
                 }
+                
+                $propertyTest = Test-SPDSCObjectHasProperty -Object $params.IncrementalSchedule `
+                                                            -PropertyName "StartHour"
+                if ($propertyTest -eq $true)
+                {
+                    $incrementalSetArgs.Add("CrawlScheduleStartDateTime", 
+                        "$($params.IncrementalSchedule.StartHour):$($params.IncrementalSchedule.StartMinute)")
+                }
                 Set-SPEnterpriseSearchCrawlContentSource @allSetArguments @incrementalSetArgs
             }
             
@@ -592,6 +600,14 @@ function Set-TargetResource
                 {
                     $fullSetArgs.Add("CrawlScheduleRunEveryInterval", 
                         $params.FullSchedule.CrawlScheduleRunEveryInterval)
+                }
+                
+                $propertyTest = Test-SPDSCObjectHasProperty -Object $params.FullSchedule `
+                                                            -PropertyName "StartHour"
+                if ($propertyTest -eq $true)
+                {
+                    $fullSetArgs.Add("CrawlScheduleStartDateTime", 
+                        "$($params.FullSchedule.StartHour):$($params.FullSchedule.StartMinute)")
                 }
                 Set-SPEnterpriseSearchCrawlContentSource @allSetArguments @fullSetArgs
             }


### PR DESCRIPTION
Regarding issue MSFT_SPSearchContentSource does not take StartHour parameter for schedule #840

I was able to solve this issue, but I must admit that I am a newbie regarding the pull request process...

So here it is. From what I was able to understand, the StartHour parameter is correctly checked in the test Get-SPDSCSearchCrawlSchedule.psm1 module.
The issue seems to be in the MSFT_SPSearchContentSource.psm1, as in its Set-TargetResource function there is never the parameter CrawlScheduleStartDateTime which is required by the sharepoint powershell cmdlet Set-SPEnterpriseSearchCrawlContentSource to had a start hour to the schedule.

Hope it helps.

